### PR TITLE
Fixing CLI docs link + binder folder comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ packages:
 #!/bin/bash
 quilt install
 ```
-If your are adopting the `binder` folder pattern to keep all your repo2dockerfiles configuration files and putting your `quilt.yml` inside of it, your `postBuild` file should look like this:
+If you are adopting the `binder` folder pattern for your `repo2docker` configuration files, and including `quilt.yml`, your `postBuild` file should look like this:
 
 ```bash
 #!/bin/bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Data packages are versioned, immutable snapshots of data. Data packages may cont
 
 1. Add `quilt` to `requirements.txt`
 
-2. Specify data package dependencies in `quilt.yml` ([docs](https://docs.quiltdata.com/cli.html)). For example:
+2. Specify data package dependencies in `quilt.yml` ([docs](https://docs.quiltdata.com/api/api-cli)). For example:
 
 ```
 packages:
@@ -25,6 +25,13 @@ packages:
 #!/bin/bash
 quilt install
 ```
+If your are adopting the `binder` folder pattern to keep all your repo2dockerfiles configuration files and putting your `quilt.yml` inside of it, your `postBuild` file should look like this:
+
+```bash
+#!/bin/bash
+quilt install @./binder/quilt.yml
+```
+
     
 Now you can access the package data in your Jupyter notebooks:
 ```


### PR DESCRIPTION
(i've suggested the same fix to the binder-examples)

I've noticed that most projects are putting all the repo2docker configuration files (postBuild, apt.txt etc.) within the a `binder` folder. Naturally, some of people (me included) tried to keep the project clean by putting the suggested quilt.yml file within the binder folder too, causing an error during image building.
I'm suggesting an additional comment on the readme to indicate that the filepath should be pointed, preceded by an @, in the postBuild file.

I also fixed the link to the CLI docs on Quilt's website.